### PR TITLE
Add stats API route

### DIFF
--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const records = globalThis.server?.schema.all('record').models;
+
+  if (!records) {
+    return NextResponse.json({ count: 0, avg: 0 }, { status: 200 });
+  }
+
+  const count = records.length;
+  const avg = records.reduce((sum, record) => sum + record.emotion, 0) / count;
+
+  return NextResponse.json({ count, avg }, { status: 200 });
+}

--- a/src/mirage/index.ts
+++ b/src/mirage/index.ts
@@ -1,4 +1,9 @@
 import { makeServer } from "./server";
+
+declare global {
+  var server: ReturnType<typeof makeServer>;
+}
+
 if (typeof window !== "undefined" && process.env.NODE_ENV === "development") {
-  makeServer();
+  globalThis.server = makeServer();
 }


### PR DESCRIPTION
Create `src/app/api/stats/route.ts` to aggregate Mirage DB records and return JSON with status 200 and type `{ avg: number; count: number }`.

* Import `NextResponse` from `next/server`.
* Create an async function `GET` to handle the request.
* Fetch all records from `globalThis.server?.schema.all('record')`.
* Calculate the average emotion score using `reduce`.
* Return the count and average in JSON format with status 200.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/yka_ikiiki_record/pull/1?shareId=111bfcc3-56b9-4f74-87d3-5c2e25056794).